### PR TITLE
[DOCS] adding visnights example to documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,8 +25,15 @@ sys.path.insert(0, os.path.abspath('..'))
 
 import hts
 
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.viewcode', 'sphinx.ext.napoleon', 'sphinx.ext.todo',
-              'sphinx.ext.autosectionlabel']
+extensions = [
+    'sphinx.ext.autodoc', 
+    'sphinx.ext.viewcode', 
+    'sphinx.ext.napoleon', 
+    'sphinx.ext.todo',
+    'sphinx.ext.autosectionlabel',
+    'nbsphinx'
+    ]
+
 autodoc_mock_imports = ['fbprophet', 'h3', 'pmdarima']
 
 napoleon_numpy_docstring = True

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,6 +8,7 @@ Welcome to scikit-hts's documentation!
    readme
    installation
    usage
+   visnights
    hierarchy
    models
    geo

--- a/reqs/extras/dev.txt
+++ b/reqs/extras/dev.txt
@@ -1,5 +1,6 @@
 bumpversion==0.5.3
 sphinx-rtd-theme==0.4.3
+nbsphinx==0.6.1
 numpydoc==0.9.1
 numpy>=1.17.4
 pandas>=0.25.3


### PR DESCRIPTION
I Introduced a familiar example in Hyndman's book using visnights data that is already on scikit-hts-examples repo, but I really think that is more evident when at least one simple example is in documentation page so people do not need to open multiple sources to check how we apply things with scikit-hts.

