### PR TITLE
Adds the option for no revision

### DIFF
--- a/hts/_t.py
+++ b/hts/_t.py
@@ -180,6 +180,7 @@ class MethodsT(ExtendedEnum):
     PHA = 'PHA'
     AHP = 'AHP'
     BU = 'BU'
+    NONE = 'NONE'
 
 
 # TODO: make this a proper recursive type when mypy supports it: https://github.com/python/mypy/issues/731

--- a/hts/revision.py
+++ b/hts/revision.py
@@ -42,6 +42,9 @@ class RevisionMethod(object):
         -------
 
         """
+        if self.name == MethodsT.NONE.name:
+            return y_hat_matrix(forecasts = forecasts)
+
         if self.name in [MethodsT.OLS.name, MethodsT.WLSS.name, MethodsT.WLSV.name]:
             return optimal_combination(forecasts=forecasts,
                                        sum_mat=self.sum_mat,

--- a/tests/unit/test_revision.py
+++ b/tests/unit/test_revision.py
@@ -8,7 +8,7 @@ def test_instantiate_revision(load_df_and_hier_uv):
     hierarchical_sine_data, sine_hier = load_df_and_hier_uv
     hsd = hierarchical_sine_data.head(200)
 
-    for method in ['OLS', 'FP', 'WLSS', 'WLSV', 'PHA', 'AHP']:
+    for method in ['OLS', 'FP', 'WLSS', 'WLSV', 'PHA', 'AHP', 'NONE']:
         ht = HTSRegressor(model='holt_winters', revision_method=method)
         ht.fit(df=hsd, nodes=sine_hier)
 


### PR DESCRIPTION
Adds the option to specify method=NONE to the htsregressor so that no revision method is used and the original forecasts are returned