### PR TITLE
Fixes bug for WLSS/WLSV revision methods and changes test_revision dataset 

### DIFF
--- a/hts/revision.py
+++ b/hts/revision.py
@@ -48,7 +48,7 @@ class RevisionMethod(object):
         if self.name in [MethodsT.OLS.name, MethodsT.WLSS.name, MethodsT.WLSV.name]:
             return optimal_combination(forecasts=forecasts,
                                        sum_mat=self.sum_mat,
-                                       method=MethodsT.OLS.name,
+                                       method=self.name,
                                        mse=mse)
 
         elif self.name == MethodsT.BU.name:

--- a/tests/unit/test_revision.py
+++ b/tests/unit/test_revision.py
@@ -4,13 +4,12 @@ from hts import HTSRegressor
 from hts.revision import RevisionMethod
 
 
-def test_instantiate_revision(load_df_and_hier_uv):
-    hierarchical_sine_data, sine_hier = load_df_and_hier_uv
-    hsd = hierarchical_sine_data.head(200)
+def test_instantiate_revision(load_df_and_hier_visnights):
+    hierarchical_visnights_data, visnights_hier = load_df_and_hier_visnights
 
     for method in ['OLS', 'FP', 'WLSS', 'WLSV', 'PHA', 'AHP', 'NONE']:
         ht = HTSRegressor(model='holt_winters', revision_method=method)
-        ht.fit(df=hsd, nodes=sine_hier)
+        ht.fit(df=hierarchical_visnights_data, nodes=visnights_hier)
 
         rm = RevisionMethod(method, sum_mat=ht.sum_mat, transformer=ht.transform)
 
@@ -21,4 +20,4 @@ def test_instantiate_revision(load_df_and_hier_uv):
             nodes=ht.nodes
         )
         assert isinstance(revised, numpy.ndarray)
-        assert revised.shape == (203, len(ht.hts_result.forecasts))
+        assert revised.shape == (11, len(ht.hts_result.forecasts))


### PR DESCRIPTION
Fixes #22: bug where WLSV and WLSS revision methods are treated as OLS. Changes the dataset used in test_revision.py to be the vis_nights dataset to avoid singular matrix error.