### PR TITLE
Fix docstring  from nodes

### DIFF
--- a/hts/hierarchy/__init__.py
+++ b/hts/hierarchy/__init__.py
@@ -106,7 +106,7 @@ class HierarchyTree(NAryTreeT):
         In this example we will create a tree from some multivariate data
 
         >>> from hts.utilities.load_data import load_mobility_data
-        >>> from hts import HierarchyTree
+        >>> from hts.hierarchy import HierarchyTree
 
         >>> hmv = load_mobility_data()
         >>> hmv.head()

--- a/hts/hierarchy/__init__.py
+++ b/hts/hierarchy/__init__.py
@@ -79,7 +79,7 @@ class HierarchyTree(NAryTreeT):
         """
         Standard method for creating a hierarchy from nodes and a dataframe containing as columns those nodes.
         The nodes are represented as a dictionary containing as keys the nodes, and as values list of edges.
-        See the examples for usage.
+        See the examples for usage. The total column must be named total and not something else.
 
         Parameters
         ----------


### PR DESCRIPTION
The example provided in the docstring does not work because of an error in the import statement, which I have corrected here. The documentation should also state that the `total` column has to be named `total` and not something else eg. not `total_size` as this caught me out when trying to use the package. There are 2 tweaks to the documentation:
  - Say that the total column must be named total and not something else.
  - Correct erroneous import statement in the example
