### PR TITLE
Build hierarchy from tabular data

### DIFF
--- a/hts/functions.py
+++ b/hts/functions.py
@@ -8,7 +8,9 @@ from hts._t import MethodT, NAryTreeT
 from hts.hierarchy import make_iterable
 
 
-def to_sum_mat(ntree: NAryTreeT) -> Tuple[np.ndarray, List[str]]:
+def to_sum_mat(
+    ntree: NAryTreeT=None, node_labels: List[str] = None
+) -> Tuple[np.ndarray, List[str]]:
     """
     This function creates a summing matrix for the bottom up and optimal combination approaches
     All the inputs are the same as above
@@ -28,10 +30,15 @@ def to_sum_mat(ntree: NAryTreeT) -> Tuple[np.ndarray, List[str]]:
         Row order list of the level in the hierarchy represented by each row in the summing matrix.
 
     """
-    nodes = ntree.level_order_traversal()
-    node_labels = ntree.get_level_order_labels()
-    num_at_level = list(map(sum, nodes))
-    columns = num_at_level[-1]
+    if node_labels:
+        columns = len(node_labels[-1])
+    elif ntree:
+        nodes = ntree.level_order_traversal()
+        node_labels = ntree.get_level_order_labels()
+        num_at_level = list(map(sum, nodes))
+        columns = num_at_level[-1]
+    else:
+        raise ValueError("Must pass either ntree or node_labels to the function. Neither was received.")
 
     # Initialize summing matrix with bottom level rows
     sum_mat = np.identity(columns)
@@ -222,3 +229,171 @@ def forecast_proportions(forecasts, nodes):
             column += 1
             first_node += num_child
     return new_mat
+
+
+def get_agg_series(df: pandas.DataFrame, levels: List[List[str]]) -> List[str]:
+    """Get aggregate level series names.
+
+    Args:
+        df (pandas.DataFrame): Tabular data.
+        levels (List[List[str]]): List of lists containing the desired level of aggregation.
+
+    Returns:
+        List[str]: Aggregate series names.
+    """
+    grouped_levels = []
+    for level in levels:
+        cross_vals = list(
+            "_".join(x for x in y) for y in df[level].drop_duplicates().values
+        )
+        grouped_levels += cross_vals
+    return grouped_levels
+
+
+def _create_bl_str_col(df: pandas.DataFrame, bl_colnames: List[str]) -> List[str]:
+    """Concatenate the column values of all the specified bl_colnames by row into a single column.
+
+    Args:
+        df (pd.DataFrame): Tabular data.
+        bl_colnames (List[str]): Levels in the hierarchy.
+
+    Returns:
+        List[str]: Concatendated column values by row.
+    """
+    return list("_".join(x for x in y) for y in df[bl_colnames].values)
+
+
+def add_agg_series_to_df(
+    df: pandas.DataFrame, grouped_levels: List[str], bottom_levels: List[str]
+) -> pandas.DataFrame:
+    """Add aggregate series columns to wide dataframe.
+
+    Args:
+        df (pandas.DataFrame): Wide dataframe containing bottom level series.
+        grouped_levels (List[str]): Grouped level, underscore delimited, column names.
+        bottom_levels (List[str]): Bottom level, underscore delimited, column names.
+
+    Returns:
+        pandas.DataFrame: Wide dataframe with all series in hierarchy.
+    """
+    component_cols = _get_bl(grouped_levels, bottom_levels)
+    # Add series as specified grouping levels
+    for i, cols in enumerate(component_cols):
+        df[grouped_levels[i]] = df[cols].sum(axis=1)
+    return df
+
+
+def _get_bl(grouped_levels: List[str], bottom_levels: List[str]) -> List[List[str]]:
+    """Get bottom level columns required to sum to create grouped columns
+
+    Args:
+        grouped_levels (List[str]): Grouped level, underscore delimited, column names.
+        bottom_levels (List[str]): Bottom level, underscore delimited, column names.
+
+    Returns:
+        List[List[str]]: Bottom level column names that make up each individual aggregated node in the hierarchy.
+    """
+    # Split groupings by "_" b/c this makes it possible to search column names
+    grouped_levels_split = [lev.split("_") for lev in grouped_levels]
+    bottom_levels_split = [lev.split("_") for lev in bottom_levels]
+
+    cols_to_add = []
+    for lev in grouped_levels_split:
+        group_bl_cols = [
+            bl_col for bl_col in bottom_levels_split if set(lev).issubset(bl_col)
+        ]
+        cols_to_add.append(["_".join(lev) for lev in group_bl_cols])
+    return cols_to_add
+
+
+def get_hierarchichal_df(
+    df: pandas.DataFrame,
+    bl_colnames: List[str],
+    hierarchical_struc: List[List[str]],
+    date_colname: str,
+    val_colname: str,
+) -> Tuple[pandas.DataFrame, np.array, List[str]]:
+    """Transform your tabular dataframe to a wide dataframe with desired levels a hierarchy.
+
+    Args:
+        df (pd.DataFrame): Tabular dataframe
+        bl_colnames (List[str]): Levels in the hierarchy.
+        hierarchical_struc (List[List[str]]): Desired levels in your hierarchy.
+        date_colname (str): Date column name
+        val_colname (str): Name of column containing series values.
+
+    Returns:
+        Tuple[pd.DataFrame, np.array, List[str]]: Wide dataframe with levels of specified aggregation. Summing matrix. Summing matrix labels.
+
+    Examples
+    --------
+    >>> hier_df = pandas.DataFrame(
+        data={
+            'ds': ['2020-01', '2020-02'] * 5,
+            "lev1": ['A', 'A',
+                     'A', 'A',
+                     'A', 'A',
+                     'B', 'B',
+                     'B', 'B'],
+            "lev2": ['X', 'X',
+                     'Y', 'Y',
+                     'Z', 'Z',
+                     'X', 'X',
+                     'Y', 'Y'],
+            "val": [1, 2,
+                    3, 4,
+                    5, 6,
+                    7, 8,
+                    9, 10]
+        }
+    )
+    >>> hier_df
+            ds lev1 lev2  val
+    0  2020-01    A    X    1
+    1  2020-02    A    X    2
+    2  2020-01    A    Y    3
+    3  2020-02    A    Y    4
+    4  2020-01    A    Z    5
+    5  2020-02    A    Z    6
+    6  2020-01    B    X    7
+    7  2020-02    B    X    8
+    8  2020-01    B    Y    9
+    9  2020-02    B    Y   10
+    >>> bl_colnames = ['lev1', 'lev2']
+    >>> hier_struc = [['lev1'], ['lev2']]
+    >>> gts_df = timewasted.gts.get_hierarchichal_df(hier_df,
+                                                     bl_colnames=bl_colnames,
+                                                     hierarchical_struc=hier_struc,
+                                                     date_colname='ds',
+                                                     val_colname='val')
+    >>> gts_df
+        lev1_lev2  A_X  A_Y  A_Z  B_X  B_Y  total   A   B   X   Y  Z
+        ds
+        2020-01      1    3    5    7    9     25   9  16   8  12  5
+        2020-02      2    4    6    8   10     30  12  18  10  14  6
+    """
+    # Column names separated by underscores
+    bl_colnames_underscores = "_".join(bl_colnames)
+
+    # Create a column representing the bottom level of aggregation
+    df[bl_colnames_underscores] = _create_bl_str_col(df, bl_colnames)
+
+    # Pivot df to bottom level. We can create the aggregate these series to get all the higher levels.
+    forecast_df = df.pivot(
+        index=date_colname, columns=bl_colnames_underscores, values=val_colname
+    )
+
+    # Sum all bottom level series to get total
+    forecast_df["total"] = forecast_df.sum(axis=1)
+
+    bottom_levels = list(df[bl_colnames_underscores].unique())
+
+    grouped_levels = get_agg_series(df, hierarchical_struc)
+
+    sum_mat, sum_mat_labels = to_sum_mat(
+        ntree=None, node_labels=[["total"], grouped_levels, bottom_levels]
+    )
+
+    forecast_df = add_agg_series_to_df(forecast_df, grouped_levels, bottom_levels)
+
+    return forecast_df, sum_mat, sum_mat_labels

--- a/hts/functions.py
+++ b/hts/functions.py
@@ -232,14 +232,20 @@ def forecast_proportions(forecasts, nodes):
 
 
 def get_agg_series(df: pandas.DataFrame, levels: List[List[str]]) -> List[str]:
-    """Get aggregate level series names.
+    """
+    Get aggregate level series names.
 
-    Args:
-        df (pandas.DataFrame): Tabular data.
-        levels (List[List[str]]): List of lists containing the desired level of aggregation.
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        Tabular data.
+    levels : List[List[str]]
+        List of lists containing the desired level of aggregation.
 
-    Returns:
-        List[str]: Aggregate series names.
+    Returns
+    -------
+    List[str]
+        Aggregate series names.
     """
     grouped_levels = []
     for level in levels:
@@ -251,14 +257,20 @@ def get_agg_series(df: pandas.DataFrame, levels: List[List[str]]) -> List[str]:
 
 
 def _create_bl_str_col(df: pandas.DataFrame, bl_colnames: List[str]) -> List[str]:
-    """Concatenate the column values of all the specified bl_colnames by row into a single column.
+    """
+    Concatenate the column values of all the specified bl_colnames by row into a single column.
 
-    Args:
-        df (pd.DataFrame): Tabular data.
-        bl_colnames (List[str]): Levels in the hierarchy.
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        Tabular data.
+    bl_colnames : List[str]
+        Levels in the hierarchy.
 
-    Returns:
-        List[str]: Concatendated column values by row.
+    Returns
+    -------
+    List[str]
+        Concatendated column values by row.
     """
     return list("_".join(x for x in y) for y in df[bl_colnames].values)
 
@@ -266,15 +278,22 @@ def _create_bl_str_col(df: pandas.DataFrame, bl_colnames: List[str]) -> List[str
 def add_agg_series_to_df(
     df: pandas.DataFrame, grouped_levels: List[str], bottom_levels: List[str]
 ) -> pandas.DataFrame:
-    """Add aggregate series columns to wide dataframe.
+    """
+    Add aggregate series columns to wide dataframe.
 
-    Args:
-        df (pandas.DataFrame): Wide dataframe containing bottom level series.
-        grouped_levels (List[str]): Grouped level, underscore delimited, column names.
-        bottom_levels (List[str]): Bottom level, underscore delimited, column names.
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        Wide dataframe containing bottom level series.
+    grouped_levels : List[str]
+        Grouped level, underscore delimited, column names.
+    bottom_levels : List[str]
+        Bottom level, underscore delimited, column names.
 
-    Returns:
-        pandas.DataFrame: Wide dataframe with all series in hierarchy.
+    Returns
+    -------
+    pandas.DataFrame
+        Wide dataframe with all series in hierarchy.
     """
     component_cols = _get_bl(grouped_levels, bottom_levels)
     # Add series as specified grouping levels
@@ -284,14 +303,20 @@ def add_agg_series_to_df(
 
 
 def _get_bl(grouped_levels: List[str], bottom_levels: List[str]) -> List[List[str]]:
-    """Get bottom level columns required to sum to create grouped columns
+    """
+    Get bottom level columns required to sum to create grouped columns.
 
-    Args:
-        grouped_levels (List[str]): Grouped level, underscore delimited, column names.
-        bottom_levels (List[str]): Bottom level, underscore delimited, column names.
+    Parameters
+    ----------
+    grouped_levels : List[str]
+        Grouped level, underscore delimited, column names.
+    bottom_levels : List[str]
+        Bottom level, underscore delimited, column names.
 
-    Returns:
-        List[List[str]]: Bottom level column names that make up each individual aggregated node in the hierarchy.
+    Returns
+    -------
+    List[List[str]]
+        Bottom level column names that make up each individual aggregated node in the hierarchy.
     """
     # Split groupings by "_" b/c this makes it possible to search column names
     grouped_levels_split = [lev.split("_") for lev in grouped_levels]
@@ -313,17 +338,32 @@ def get_hierarchichal_df(
     date_colname: str,
     val_colname: str,
 ) -> Tuple[pandas.DataFrame, np.array, List[str]]:
-    """Transform your tabular dataframe to a wide dataframe with desired levels a hierarchy.
+    """
+    Transform your tabular dataframe to a wide dataframe with desired levels a hierarchy.
 
-    Args:
-        df (pd.DataFrame): Tabular dataframe
-        bl_colnames (List[str]): Levels in the hierarchy.
-        hierarchical_struc (List[List[str]]): Desired levels in your hierarchy.
-        date_colname (str): Date column name
-        val_colname (str): Name of column containing series values.
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Tabular dataframe
+    bl_colnames : List[str]
+        Levels in the hierarchy.
+    hierarchical_struc : List[List[str]]
+        Desired levels in your hierarchy.
+    date_colname : str
+        Date column name
+    val_colname : str
+        Name of column containing series values.
 
-    Returns:
-        Tuple[pd.DataFrame, np.array, List[str]]: Wide dataframe with levels of specified aggregation. Summing matrix. Summing matrix labels.
+    Returns
+    -------
+    pd.DataFrame
+        Wide dataframe with levels of specified aggregation.
+
+    np.array
+        Summing matrix.
+
+    List[str]:
+        Summing matrix labels.
 
     Examples
     --------

--- a/hts/functions.py
+++ b/hts/functions.py
@@ -20,6 +20,8 @@ def to_sum_mat(
     ----------
     ntree : NAryTreeT
 
+    node_labels : List[str]
+        Labels corresponing to node names/ summing matrix. Get from hts.functions.get_hierarchichal_df(...)
 
     Returns
     -------

--- a/hts/functions.py
+++ b/hts/functions.py
@@ -334,7 +334,7 @@ def _get_bl(grouped_levels: List[str], bottom_levels: List[str]) -> List[List[st
 def get_hierarchichal_df(
     df: pandas.DataFrame,
     bl_colnames: List[str],
-    hierarchical_struc: List[List[str]],
+    hierarchy: List[List[str]],
     date_colname: str,
     val_colname: str,
 ) -> Tuple[pandas.DataFrame, np.array, List[str]]:
@@ -347,7 +347,7 @@ def get_hierarchichal_df(
         Tabular dataframe
     bl_colnames : List[str]
         Levels in the hierarchy.
-    hierarchical_struc : List[List[str]]
+    hierarchy : List[List[str]]
         Desired levels in your hierarchy.
     date_colname : str
         Date column name
@@ -367,6 +367,7 @@ def get_hierarchichal_df(
 
     Examples
     --------
+    >>> import hts.functions
     >>> hier_df = pandas.DataFrame(
         data={
             'ds': ['2020-01', '2020-02'] * 5,
@@ -400,13 +401,13 @@ def get_hierarchichal_df(
     8  2020-01    B    Y    9
     9  2020-02    B    Y   10
     >>> bl_colnames = ['lev1', 'lev2']
-    >>> hier_struc = [['lev1'], ['lev2']]
-    >>> gts_df = timewasted.gts.get_hierarchichal_df(hier_df,
-                                                     bl_colnames=bl_colnames,
-                                                     hierarchical_struc=hier_struc,
-                                                     date_colname='ds',
-                                                     val_colname='val')
-    >>> gts_df
+    >>> hierarchy = [['lev1'], ['lev2']]
+    >>> wide_df = hts.functions.get_hierarchichal_df(hier_df,
+                                                    bl_colnames=bl_colnames,
+                                                    hierarchy=hierarchy,
+                                                    date_colname='ds',
+                                                    val_colname='val')
+    >>> wide_df
         lev1_lev2  A_X  A_Y  A_Z  B_X  B_Y  total   A   B   X   Y  Z
         ds
         2020-01      1    3    5    7    9     25   9  16   8  12  5
@@ -428,7 +429,7 @@ def get_hierarchichal_df(
 
     bottom_levels = list(df[bl_colnames_underscores].unique())
 
-    grouped_levels = get_agg_series(df, hierarchical_struc)
+    grouped_levels = get_agg_series(df, hierarchy)
 
     sum_mat, sum_mat_labels = to_sum_mat(
         ntree=None, node_labels=[["total"], grouped_levels, bottom_levels]

--- a/hts/functions.py
+++ b/hts/functions.py
@@ -9,7 +9,7 @@ from hts.hierarchy import make_iterable
 
 
 def to_sum_mat(
-    ntree: NAryTreeT=None, node_labels: List[str] = None
+    ntree: NAryTreeT = None, node_labels: List[str] = None
 ) -> Tuple[np.ndarray, List[str]]:
     """
     This function creates a summing matrix for the bottom up and optimal combination approaches
@@ -40,7 +40,9 @@ def to_sum_mat(
         num_at_level = list(map(sum, nodes))
         columns = num_at_level[-1]
     else:
-        raise ValueError("Must pass either ntree or node_labels to the function. Neither was received.")
+        raise ValueError(
+            "Must pass either ntree or node_labels to the function. Neither was received."
+        )
 
     # Initialize summing matrix with bottom level rows
     sum_mat = np.identity(columns)

--- a/hts/functions.py
+++ b/hts/functions.py
@@ -404,11 +404,11 @@ def get_hierarchichal_df(
     9  2020-02    B    Y   10
     >>> level_names = ['lev1', 'lev2']
     >>> hierarchy = [['lev1'], ['lev2']]
-    >>> wide_df = hts.functions.get_hierarchichal_df(hier_df,
-                                                    level_names=level_names,
-                                                    hierarchy=hierarchy,
-                                                    date_colname='ds',
-                                                    val_colname='val')
+    >>> wide_df, sum_mat, sum_mat_labels = hts.functions.get_hierarchichal_df(hier_df,
+                                                                              level_names=level_names,
+                                                                              hierarchy=hierarchy,
+                                                                              date_colname='ds',
+                                                                              val_colname='val')
     >>> wide_df
         lev1_lev2  A_X  A_Y  A_Z  B_X  B_Y  total   A   B   X   Y  Z
         ds

--- a/hts/functions.py
+++ b/hts/functions.py
@@ -256,15 +256,15 @@ def get_agg_series(df: pandas.DataFrame, levels: List[List[str]]) -> List[str]:
     return grouped_levels
 
 
-def _create_bl_str_col(df: pandas.DataFrame, bl_colnames: List[str]) -> List[str]:
+def _create_bl_str_col(df: pandas.DataFrame, level_names: List[str]) -> List[str]:
     """
-    Concatenate the column values of all the specified bl_colnames by row into a single column.
+    Concatenate the column values of all the specified level_names by row into a single column.
 
     Parameters
     ----------
     df : pandas.DataFrame
         Tabular data.
-    bl_colnames : List[str]
+    level_names : List[str]
         Levels in the hierarchy.
 
     Returns
@@ -272,7 +272,7 @@ def _create_bl_str_col(df: pandas.DataFrame, bl_colnames: List[str]) -> List[str
     List[str]
         Concatendated column values by row.
     """
-    return list("_".join(x for x in y) for y in df[bl_colnames].values)
+    return list("_".join(x for x in y) for y in df[level_names].values)
 
 
 def add_agg_series_to_df(
@@ -333,7 +333,7 @@ def _get_bl(grouped_levels: List[str], bottom_levels: List[str]) -> List[List[st
 
 def get_hierarchichal_df(
     df: pandas.DataFrame,
-    bl_colnames: List[str],
+    level_names: List[str],
     hierarchy: List[List[str]],
     date_colname: str,
     val_colname: str,
@@ -345,7 +345,7 @@ def get_hierarchichal_df(
     ----------
     df : pd.DataFrame
         Tabular dataframe
-    bl_colnames : List[str]
+    level_names : List[str]
         Levels in the hierarchy.
     hierarchy : List[List[str]]
         Desired levels in your hierarchy.
@@ -400,10 +400,10 @@ def get_hierarchichal_df(
     7  2020-02    B    X    8
     8  2020-01    B    Y    9
     9  2020-02    B    Y   10
-    >>> bl_colnames = ['lev1', 'lev2']
+    >>> level_names = ['lev1', 'lev2']
     >>> hierarchy = [['lev1'], ['lev2']]
     >>> wide_df = hts.functions.get_hierarchichal_df(hier_df,
-                                                    bl_colnames=bl_colnames,
+                                                    level_names=level_names,
                                                     hierarchy=hierarchy,
                                                     date_colname='ds',
                                                     val_colname='val')
@@ -414,20 +414,20 @@ def get_hierarchichal_df(
         2020-02      2    4    6    8   10     30  12  18  10  14  6
     """
     # Column names separated by underscores
-    bl_colnames_underscores = "_".join(bl_colnames)
+    level_names_underscores = "_".join(level_names)
 
     # Create a column representing the bottom level of aggregation
-    df[bl_colnames_underscores] = _create_bl_str_col(df, bl_colnames)
+    df[level_names_underscores] = _create_bl_str_col(df, level_names)
 
     # Pivot df to bottom level. We can create the aggregate these series to get all the higher levels.
     forecast_df = df.pivot(
-        index=date_colname, columns=bl_colnames_underscores, values=val_colname
+        index=date_colname, columns=level_names_underscores, values=val_colname
     )
 
     # Sum all bottom level series to get total
     forecast_df["total"] = forecast_df.sum(axis=1)
 
-    bottom_levels = list(df[bl_colnames_underscores].unique())
+    bottom_levels = list(df[level_names_underscores].unique())
 
     grouped_levels = get_agg_series(df, hierarchy)
 

--- a/tests/unit/test_functions.py
+++ b/tests/unit/test_functions.py
@@ -251,8 +251,8 @@ def test_grouped():
         data={"lev1": ["A", "A", "A", "B", "B"], "lev2": ["X", "Y", "Z", "X", "Y"],}
     )
 
-    hier_struc = [["lev1"], ["lev2"], ["lev1", "lev2"]]
-    levels = get_agg_series(hier_df, hier_struc)
+    hierarchy = [["lev1"], ["lev2"], ["lev1", "lev2"]]
+    levels = get_agg_series(hier_df, hierarchy)
     expected_levels = ["A", "B", "X", "Y", "Z", "A_X", "A_Y", "A_Z", "B_X", "B_Y"]
     assert sorted(levels) == sorted(expected_levels)
 
@@ -267,12 +267,12 @@ def test_grouped_create_df():
         }
     )
 
-    bl_colnames = ["lev1", "lev2"]
-    hier_struc = [["lev1"], ["lev2"]]
+    level_names = ["lev1", "lev2"]
+    hierarchy = [["lev1"], ["lev2"]]
     gts_df, sum_mat, sum_mat_labels = get_hierarchichal_df(
         hier_df,
-        bl_colnames=bl_colnames,
-        hierarchical_struc=hier_struc,
+        level_names=level_names,
+        hierarchy=hierarchy,
         date_colname="ds",
         val_colname="val",
     )

--- a/tests/unit/test_functions.py
+++ b/tests/unit/test_functions.py
@@ -295,8 +295,7 @@ def test_grouped_create_df():
 
 def test_parent_child():
     grouped_df = pandas.DataFrame(
-        data={"lev1": ["A", "A", "B"],
-              "lev2": ["X", "Y", "Z"],}
+        data={"lev1": ["A", "A", "B"], "lev2": ["X", "Y", "Z"],}
     )
 
     levels = get_agg_series(grouped_df, [["lev1", "lev2"]])
@@ -306,8 +305,7 @@ def test_parent_child():
 
 def test_create_bl_str_col():
     grouped_df = pandas.DataFrame(
-        data={"lev1": ["A", "A", "B"],
-             "lev2": ["X", "Y", "Z"],}
+        data={"lev1": ["A", "A", "B"], "lev2": ["X", "Y", "Z"],}
     )
 
     col = _create_bl_str_col(grouped_df, ["lev1", "lev2"])

--- a/tests/unit/test_functions.py
+++ b/tests/unit/test_functions.py
@@ -2,7 +2,12 @@ import numpy
 import pandas
 
 import hts.hierarchy
-from hts.functions import to_sum_mat
+from hts.functions import (
+    _create_bl_str_col,
+    get_agg_series,
+    get_hierarchichal_df,
+    to_sum_mat,
+)
 
 
 def test_sum_mat_uv(uv_tree):
@@ -203,3 +208,108 @@ def test_demo_unique_constraint():
     )
 
     numpy.testing.assert_array_equal(sum_mat, expected_sum_mat)
+
+
+def test_1lev():
+    grouped_df = pandas.DataFrame(
+        data={"lev1": ["A", "A", "B", "B"], "lev2": ["X", "Y", "X", "Y"],}
+    )
+
+    levels = get_agg_series(grouped_df, [["lev1"]])
+    expected_levels = ["A", "B"]
+    assert sorted(levels) == sorted(expected_levels)
+
+    levels = get_agg_series(grouped_df, [["lev2"]])
+    expected_levels = ["X", "Y"]
+    assert sorted(levels) == sorted(expected_levels)
+
+
+def test_2lev():
+    grouped_df = pandas.DataFrame(
+        data={"lev1": ["A", "A", "B", "B"], "lev2": ["X", "Y", "X", "Y"],}
+    )
+
+    levels = get_agg_series(grouped_df, [["lev1", "lev2"]])
+
+    expected_levels = ["A_X", "A_Y", "B_X", "B_Y"]
+
+    assert sorted(levels) == sorted(expected_levels)
+
+
+def test_hierarchichal():
+    hier_df = pandas.DataFrame(
+        data={"lev1": ["A", "A", "A", "B", "B"], "lev2": ["X", "Y", "Z", "X", "Y"],}
+    )
+
+    levels = get_agg_series(hier_df, [["lev1"], ["lev1", "lev2"]])
+    expected_levels = ["A", "B", "A_X", "A_Y", "A_Z", "B_X", "B_Y"]
+    assert sorted(levels) == sorted(expected_levels)
+
+
+def test_grouped():
+    hier_df = pandas.DataFrame(
+        data={"lev1": ["A", "A", "A", "B", "B"], "lev2": ["X", "Y", "Z", "X", "Y"],}
+    )
+
+    hier_struc = [["lev1"], ["lev2"], ["lev1", "lev2"]]
+    levels = get_agg_series(hier_df, hier_struc)
+    expected_levels = ["A", "B", "X", "Y", "Z", "A_X", "A_Y", "A_Z", "B_X", "B_Y"]
+    assert sorted(levels) == sorted(expected_levels)
+
+
+def test_grouped_create_df():
+    hier_df = pandas.DataFrame(
+        data={
+            "ds": ["2020-01", "2020-02"] * 5,
+            "lev1": ["A", "A", "A", "A", "A", "A", "B", "B", "B", "B"],
+            "lev2": ["X", "X", "Y", "Y", "Z", "Z", "X", "X", "Y", "Y"],
+            "val": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        }
+    )
+
+    bl_colnames = ["lev1", "lev2"]
+    hier_struc = [["lev1"], ["lev2"]]
+    gts_df, sum_mat, sum_mat_labels = get_hierarchichal_df(
+        hier_df,
+        bl_colnames=bl_colnames,
+        hierarchical_struc=hier_struc,
+        date_colname="ds",
+        val_colname="val",
+    )
+
+    expected_columns = [
+        "A_X",
+        "A_Y",
+        "A_Z",
+        "B_X",
+        "B_Y",
+        "A",
+        "B",
+        "X",
+        "Y",
+        "Z",
+        "total",
+    ]
+    assert sorted(list(gts_df.columns)) == sorted(expected_columns)
+
+
+def test_parent_child():
+    grouped_df = pandas.DataFrame(
+        data={"lev1": ["A", "A", "B"],
+              "lev2": ["X", "Y", "Z"],}
+    )
+
+    levels = get_agg_series(grouped_df, [["lev1", "lev2"]])
+    expected_levels = ["A_X", "A_Y", "B_Z"]
+    assert sorted(levels) == sorted(expected_levels)
+
+
+def test_create_bl_str_col():
+    grouped_df = pandas.DataFrame(
+        data={"lev1": ["A", "A", "B"],
+             "lev2": ["X", "Y", "Z"],}
+    )
+
+    col = _create_bl_str_col(grouped_df, ["lev1", "lev2"])
+
+    assert col == ["A_X", "A_Y", "B_Z"]


### PR DESCRIPTION
Added the ability to build a hierarchy from tabular data, accessible through the hts.function.get_hierarchichal_df(...) function. This should allow users to take raw tabular data, build a hierarchy with a specification similar to the R hts package, receive a dataframe to make forecasts with and then reconcile those forecasts.

Pull request has documentation(usage.rst/ docstrings) and tests.

Please let me know if you'd like me to include any further details.

