### PR TITLE
Fix/exogenous variables prophet

### DIFF
--- a/hts/core/regressor.py
+++ b/hts/core/regressor.py
@@ -1,7 +1,7 @@
 import logging
 import tempfile
 from typing import Any, Dict, List, Optional, Union
-
+from datetime import timedelta
 import numpy
 import pandas
 from sklearn.base import BaseEstimator, RegressorMixin
@@ -268,12 +268,12 @@ class HTSRegressor(BaseEstimator, RegressorMixin):
                 "No arguments passed for 'steps_ahead', defaulting to predicting 1-step-ahead"
             )
             steps_ahead = 1
-        elif exogenous_df:
+        elif exogenous_df is not None:
             steps_ahead = len(exogenous_df)
             for node in make_iterable(self.nodes, prop=None):
                 exog_cols = node.exogenous
                 try:
-                    node.item = exogenous_df[exog_cols]
+                    _ = exogenous_df[exog_cols]
                 except KeyError:
                     raise MissingRegressorException(
                         f"Node {node.key} has as exogenous variables {node.exogenous} but "
@@ -364,10 +364,14 @@ class HTSRegressor(BaseEstimator, RegressorMixin):
 
     def _get_predict_index(self, steps_ahead=1) -> Any:
 
-        freq = getattr(self.nodes.item.index, "freq", 1)
-        start = self.nodes.item.index[-1] + freq
-        end = self.nodes.item.index[-1] + (steps_ahead * freq)
-
-        future = pandas.date_range(freq=freq, start=start, end=end)
+        freq = getattr(self.nodes.item.index, "freq", 1) or 1
+        try:
+            start = self.nodes.item.index[-1] + timedelta(freq)
+            end = self.nodes.item.index[-1] + timedelta(steps_ahead * freq)
+            future = pandas.date_range(start=start, end=end)
+        except TypeError:
+            start = self.nodes.item.index[-1] + freq
+            end = self.nodes.item.index[-1] + (steps_ahead * freq)
+            future = pandas.date_range(freq=freq, start=start, end=end)
 
         return self.nodes.item.index.append(future)

--- a/hts/core/regressor.py
+++ b/hts/core/regressor.py
@@ -1,7 +1,8 @@
 import logging
 import tempfile
-from typing import Any, Dict, List, Optional, Union
 from datetime import timedelta
+from typing import Any, Dict, List, Optional, Union
+
 import numpy
 import pandas
 from sklearn.base import BaseEstimator, RegressorMixin

--- a/hts/model/base.py
+++ b/hts/model/base.py
@@ -15,8 +15,8 @@ logger = logging.getLogger(__name__)
 
 
 class TimeSeriesModel(TimeSeriesModelT):
-    """ Base class for the implementation of the underlying models.
-        Inherits from scikit-learn base classes
+    """Base class for the implementation of the underlying models.
+    Inherits from scikit-learn base classes
     """
 
     def __init__(

--- a/hts/model/p.py
+++ b/hts/model/p.py
@@ -102,7 +102,6 @@ class FBProphetModel(TimeSeriesModel):
         future = self.model.make_future_dataframe(
             periods=steps_ahead, freq=freq, include_history=True
         )
-        print(f"Future: {future}\n\n\n\n")
         if exogenous_df is not None:
             previous_exogenous_values = node.to_pandas()[node.exogenous].reset_index(
                 drop=True

--- a/hts/model/p.py
+++ b/hts/model/p.py
@@ -96,10 +96,13 @@ class FBProphetModel(TimeSeriesModel):
         steps_ahead: int = 1,
         exogenous_df: pandas.DataFrame = None,
     ):
+
         df = self._pre_process(node.item)
+
         future = self.model.make_future_dataframe(
             periods=steps_ahead, freq=freq, include_history=True
         )
+        print(f"Future: {future}\n\n\n\n")
         if exogenous_df is not None:
             previous_exogenous_values = node.to_pandas()[node.exogenous].reset_index(
                 drop=True

--- a/hts/revision.py
+++ b/hts/revision.py
@@ -13,7 +13,10 @@ from hts.hierarchy.utils import make_iterable
 
 class RevisionMethod(object):
     def __init__(
-        self, name: str, sum_mat: numpy.ndarray, transformer,
+        self,
+        name: str,
+        sum_mat: numpy.ndarray,
+        transformer,
     ):
         self.name = name
         self.transformer = transformer

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,7 +113,7 @@ def hierarchical_mv_data():
 
 
 @pytest.fixture
-def mv_tree(hierarchical_mv_data):
+def mv_tree_empty():
     hier = {
         "total": ["CH", "SLU", "BT", "OTHER"],
         "CH": ["CH-07", "CH-02", "CH-08", "CH-05", "CH-01"],
@@ -121,13 +121,20 @@ def mv_tree(hierarchical_mv_data):
         "BT": ["BT-01", "BT-03"],
         "OTHER": ["WF-01", "CBD-13"],
     }
+    return hier
+
+
+@pytest.fixture
+def mv_tree(hierarchical_mv_data, mv_tree_empty):
+
     exogenous = {
         k: ["precipitation", "temp"]
         for k in hierarchical_mv_data.columns
         if k not in ["precipitation", "temp"]
     }
-
-    return HierarchyTree.from_nodes(hier, hierarchical_mv_data, exogenous=exogenous)
+    return HierarchyTree.from_nodes(
+        mv_tree_empty, hierarchical_mv_data, exogenous=exogenous
+    )
 
 
 @pytest.fixture

--- a/tests/integ/test_fit_model.py
+++ b/tests/integ/test_fit_model.py
@@ -6,7 +6,6 @@ import pytest
 from fbprophet import Prophet
 from pmdarima import AutoARIMA
 
-
 from hts.model import AutoArimaModel, FBProphetModel, HoltWintersModel, SarimaxModel
 from hts.model.base import TimeSeriesModel
 

--- a/tests/integ/test_fit_model.py
+++ b/tests/integ/test_fit_model.py
@@ -6,6 +6,7 @@ import pytest
 from fbprophet import Prophet
 from pmdarima import AutoARIMA
 
+
 from hts.model import AutoArimaModel, FBProphetModel, HoltWintersModel, SarimaxModel
 from hts.model.base import TimeSeriesModel
 
@@ -21,6 +22,17 @@ def test_instantiate_fb_model_uv(uv_tree):
 
 def test_fit_predict_fb_model_mv(mv_tree):
     exog = pandas.DataFrame({"precipitation": [1], "temp": [20]})
+    fb = FBProphetModel(node=mv_tree)
+    assert isinstance(fb, TimeSeriesModel)
+    fb.fit()
+    fb.predict(mv_tree, exogenous_df=exog)
+    assert isinstance(fb.forecast, pandas.DataFrame)
+    assert isinstance(fb.residual, numpy.ndarray)
+    assert isinstance(fb.mse, float)
+
+
+def test_fit_predict_fb_model_mv(mv_tree):
+    exog = pandas.DataFrame({"precipitation": [1, 2], "temp": [20, 30]})
     fb = FBProphetModel(node=mv_tree)
     assert isinstance(fb, TimeSeriesModel)
     fb.fit()
@@ -52,7 +64,9 @@ def test_fit_predict_ar_model_mv(mv_tree):
 
 
 def test_fit_predict_ar_model_uv(uv_tree):
-    ar = AutoArimaModel(node=uv_tree,)
+    ar = AutoArimaModel(
+        node=uv_tree,
+    )
     ar.fit(max_iter=1)
     assert isinstance(ar.model, AutoARIMA)
     ar.predict(uv_tree)
@@ -62,7 +76,10 @@ def test_fit_predict_ar_model_uv(uv_tree):
 
 
 def test_fit_predict_sarimax_model_uv(uv_tree):
-    sar = SarimaxModel(node=uv_tree, max_iter=1,)
+    sar = SarimaxModel(
+        node=uv_tree,
+        max_iter=1,
+    )
     fitted_sar = sar.fit()
     assert isinstance(fitted_sar, SarimaxModel)
     sar.predict(uv_tree)
@@ -72,7 +89,9 @@ def test_fit_predict_sarimax_model_uv(uv_tree):
 
 
 def test_fit_predict_hw_model_uv(uv_tree):
-    hw = HoltWintersModel(node=uv_tree,)
+    hw = HoltWintersModel(
+        node=uv_tree,
+    )
     fitted_hw = hw.fit()
     assert isinstance(fitted_hw, HoltWintersModel)
     hw.predict(uv_tree)

--- a/tests/integ/test_fit_regressor.py
+++ b/tests/integ/test_fit_regressor.py
@@ -1,8 +1,9 @@
+from datetime import timedelta
+
 import pandas
 
 from hts import HTSRegressor
 from hts.core.result import HTSResult
-from datetime import timedelta
 
 
 def test_instantiate_regressor():

--- a/tests/integ/test_fit_regressor.py
+++ b/tests/integ/test_fit_regressor.py
@@ -86,16 +86,15 @@ def test_exog_fit_predict_fb_model(hierarchical_mv_data, mv_tree_empty):
     }
     horizon = 7
     train = hierarchical_mv_data[:500]
-    test = hierarchical_mv_data[500:500 + horizon]
+    test = hierarchical_mv_data[500 : 500 + horizon]
     clf = HTSRegressor(model="prophet", revision_method="OLS", n_jobs=0)
     model = clf.fit(train, mv_tree_empty, exogenous=exogenous)
     preds = model.predict(exogenous_df=test)
     assert isinstance(preds, pandas.DataFrame)
 
-        # base + steps ahead
+    # base + steps ahead
     assert len(preds) == len(train) + horizon
     assert len(model.hts_result.forecasts["total"]) == len(train) + horizon
-
 
     assert len(model.hts_result.errors) == len(train.columns) - 2
 

--- a/tests/integ/test_fit_regressor.py
+++ b/tests/integ/test_fit_regressor.py
@@ -2,6 +2,7 @@ import pandas
 
 from hts import HTSRegressor
 from hts.core.result import HTSResult
+from datetime import timedelta
 
 
 def test_instantiate_regressor():
@@ -74,3 +75,16 @@ def test_predict_regressor_visnights(load_df_and_hier_visnights):
         assert "NSW" in ht.hts_result.errors
         assert "NSW" in ht.hts_result.forecasts
         assert "NSW" in ht.hts_result.residuals
+
+
+def test_exog_fit_predict_fb_model(hierarchical_mv_data, mv_tree_empty):
+    exogenous = {
+        k: ["precipitation", "temp"]
+        for k in hierarchical_mv_data.columns
+        if k not in ["precipitation", "temp"]
+    }
+    train = hierarchical_mv_data[:500]
+    test = hierarchical_mv_data[500:507]  # .loc[:, ["temp", "precipitation"]]
+    clf = HTSRegressor(model="prophet", revision_method="OLS", n_jobs=0)
+    model = clf.fit(train, mv_tree_empty, exogenous=exogenous)
+    model.predict(steps_ahead=7, exogenous_df=test)

--- a/tests/integ/test_fit_regressor.py
+++ b/tests/integ/test_fit_regressor.py
@@ -85,7 +85,7 @@ def test_exog_fit_predict_fb_model(hierarchical_mv_data, mv_tree_empty):
         if k not in ["precipitation", "temp"]
     }
     train = hierarchical_mv_data[:500]
-    test = hierarchical_mv_data[500:507]  # .loc[:, ["temp", "precipitation"]]
+    test = hierarchical_mv_data[500:507]
     clf = HTSRegressor(model="prophet", revision_method="OLS", n_jobs=0)
     model = clf.fit(train, mv_tree_empty, exogenous=exogenous)
-    model.predict(steps_ahead=7, exogenous_df=test)
+    model.predict(exogenous_df=test)

--- a/tests/unit/test_functions.py
+++ b/tests/unit/test_functions.py
@@ -19,7 +19,7 @@ def test_sum_mat_uv(uv_tree):
 
 
 def test_sum_mat_mv(mv_tree):
-    mat, sum_mat_labels = to_sum_mat(mv_tree)
+    mat, _ = to_sum_mat(mv_tree)
     assert isinstance(mat, numpy.ndarray)
     shp = mat.shape
     assert shp[0] == mv_tree.num_nodes() + 1
@@ -212,7 +212,10 @@ def test_demo_unique_constraint():
 
 def test_1lev():
     grouped_df = pandas.DataFrame(
-        data={"lev1": ["A", "A", "B", "B"], "lev2": ["X", "Y", "X", "Y"],}
+        data={
+            "lev1": ["A", "A", "B", "B"],
+            "lev2": ["X", "Y", "X", "Y"],
+        }
     )
 
     levels = get_agg_series(grouped_df, [["lev1"]])
@@ -226,7 +229,10 @@ def test_1lev():
 
 def test_2lev():
     grouped_df = pandas.DataFrame(
-        data={"lev1": ["A", "A", "B", "B"], "lev2": ["X", "Y", "X", "Y"],}
+        data={
+            "lev1": ["A", "A", "B", "B"],
+            "lev2": ["X", "Y", "X", "Y"],
+        }
     )
 
     levels = get_agg_series(grouped_df, [["lev1", "lev2"]])
@@ -238,7 +244,10 @@ def test_2lev():
 
 def test_hierarchichal():
     hier_df = pandas.DataFrame(
-        data={"lev1": ["A", "A", "A", "B", "B"], "lev2": ["X", "Y", "Z", "X", "Y"],}
+        data={
+            "lev1": ["A", "A", "A", "B", "B"],
+            "lev2": ["X", "Y", "Z", "X", "Y"],
+        }
     )
 
     levels = get_agg_series(hier_df, [["lev1"], ["lev1", "lev2"]])
@@ -248,7 +257,10 @@ def test_hierarchichal():
 
 def test_grouped():
     hier_df = pandas.DataFrame(
-        data={"lev1": ["A", "A", "A", "B", "B"], "lev2": ["X", "Y", "Z", "X", "Y"],}
+        data={
+            "lev1": ["A", "A", "A", "B", "B"],
+            "lev2": ["X", "Y", "Z", "X", "Y"],
+        }
     )
 
     hierarchy = [["lev1"], ["lev2"], ["lev1", "lev2"]]
@@ -295,7 +307,10 @@ def test_grouped_create_df():
 
 def test_parent_child():
     grouped_df = pandas.DataFrame(
-        data={"lev1": ["A", "A", "B"], "lev2": ["X", "Y", "Z"],}
+        data={
+            "lev1": ["A", "A", "B"],
+            "lev2": ["X", "Y", "Z"],
+        }
     )
 
     levels = get_agg_series(grouped_df, [["lev1", "lev2"]])
@@ -305,7 +320,10 @@ def test_parent_child():
 
 def test_create_bl_str_col():
     grouped_df = pandas.DataFrame(
-        data={"lev1": ["A", "A", "B"], "lev2": ["X", "Y", "Z"],}
+        data={
+            "lev1": ["A", "A", "B"],
+            "lev2": ["X", "Y", "Z"],
+        }
     )
 
     col = _create_bl_str_col(grouped_df, ["lev1", "lev2"])


### PR DESCRIPTION
I spent a few hours trying to understand why adding exogenous variables couldn't work properly. 
After a few small fixes, now I think it works properly at least for Facebook Prophet. 

You can take a look at the diff, but please also note that there are some changes caused by running `black`. I also edited some tests just for the sake of convenience and added a test for exogenous variables. 

If some of the changes are not okay, please let me know :) 